### PR TITLE
使用 GitHub Actions 自动构建并推送 Docker 镜像

### DIFF
--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -1,0 +1,48 @@
+name: Buildx Docker image
+
+on:
+  push:
+    branches:
+      - 'master'
+
+# Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'   
+        required: false
+        default: 'warning'
+        
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      - 
+        name: Get current date
+        id: date
+        run: echo "::set-output name=today::$(date +'%Y-%m-%d')"
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7,linux/arm/v6
+          push: true
+          tags: |
+            user/app:latest
+            user/app:${{ steps.date.outputs.today }} 

--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -44,5 +44,5 @@ jobs:
           platforms: linux/amd64,linux/arm64/v8,linux/arm/v7,linux/arm/v6
           push: true
           tags: |
-            user/app:latest
-            user/app:${{ steps.date.outputs.today }} 
+            ${{ secrets.DOCKERHUB_USERNAME }}/mihoyo-bbs:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/mihoyo-bbs:${{ steps.date.outputs.today }} 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ docker-compose logs -f
 
 每次运行Docker容器后，容器内将自动按照参数执行签到活动，签到完成后容器将默认在每天上午9:30运行一次，如果想自行修改时间可自行编辑`docker-compose.yml`文件中的`CRON_SIGNIN`，将其修改成想运行的时间。
 
+若想要更新容器镜像，可以参考以下命令
+```text
+docker-compose stop  
+docker-compose pull && docker-compose up -d
+```
+
 ## 使用python运行(screen)
 
 1. 将本项目Clone至本地后，安装好依赖直接运行`python3 server.py`


### PR DESCRIPTION
每次 matser 分支有更新时自动构建打包多平台 Docker 镜像，并自动推送到 Docker Hub。若有必要也可在 Github Action 界面手动运行。