### PR TITLE
feat: 增加bash脚本，增加logging配置文件示例

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,8 +137,12 @@ dmypy.json
 # 避免上传配置文件
 config/*.json
 config/*.yaml
+config/*.ini
 
 # push配置
 config/push.ini
 .DS_Store
 yaml/
+
+# 日志文件
+*.log

--- a/config/logging.ini.example
+++ b/config/logging.ini.example
@@ -14,13 +14,14 @@ handlers=fileHandler,consoleHandler
 
 [logger_AutoMihoyoBBS]
 level=WARNING
+qualname=fileHandler,consoleHandler
 handlers=fileHandler,consoleHandler
 
 ; console
 [handler_consoleHandler]
 class=StreamHandler
 args=(sys.stdout,)
-level=DEBUG
+level=INFO
 formatter=simpleFormatter
 
 ; file

--- a/config/logging.ini.example
+++ b/config/logging.ini.example
@@ -1,0 +1,44 @@
+[loggers]
+keys=root,AutoMihoyoBBS
+
+[handlers]
+keys=fileHandler,consoleHandler
+
+[formatters]
+keys=simpleFormatter
+
+; 缺少root logger会报错
+[logger_root]
+level=DEBUG
+handlers=fileHandler,consoleHandler
+
+[logger_AutoMihoyoBBS]
+level=WARNING
+handlers=fileHandler,consoleHandler
+
+; console
+[handler_consoleHandler]
+class=StreamHandler
+args=(sys.stdout,)
+level=DEBUG
+formatter=simpleFormatter
+
+; file
+[handler_fileHandler]
+class=FileHandler
+args=('logging.log', 'a')
+level=DEBUG
+formatter=simpleFormatter
+
+; 由于官方的SMTPHandler似乎不支持ssl邮箱，暂时不使用
+; Email
+; [handler_SMTPHandler]
+; class=handlers.SMTPHandler
+; ; logging.handlers.SMTPHandler(mailhost，fromaddr，toaddrs，subject，credentials = None，secure = None，timeout = 1.0)
+; args=()
+; level=ERROR
+; formatter=simpleFormatter
+
+[formatter_simpleFormatter]
+format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
+datefmt=%Y-%m-%dT%H:%M:%S

--- a/start.bash
+++ b/start.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+# 进入脚本所在目录
+cd $(cd `dirname $0`;pwd)
+# 随机延时$RANDOM值为1~32767
+sleep $[$RANDOM%1200];
+python ./main.py;


### PR DESCRIPTION
- bash延时脚本
- logging模块配置文件增加输出日志
#237 由于logging模块内置SMTPHandler不支持ssl，暂时未实现邮件推送。